### PR TITLE
Don't return MWEB-only transactions when rpcserialversion <= 1

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -921,6 +921,11 @@ static RPCHelpMan getmempoolentry()
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Transaction not in mempool");
     }
 
+    if (RPCSerializationFlags() & SERIALIZE_NO_MWEB && it->GetTx().IsMWEBOnly()) {
+        // Don't return MWEB-only transactions to clients that don't support them.
+        throw JSONRPCError(RPC_DESERIALIZATION_ERROR, "MWEB-only transaction not serializable for rpcserialversion<2");
+    }
+
     const CTxMemPoolEntry &e = *it;
     UniValue info(UniValue::VOBJ);
     entryToJSON(mempool, info, e);

--- a/test/functional/mweb_mempool.py
+++ b/test/functional/mweb_mempool.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+# Copyright (c) 2020 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""
+Tests mempool functionality for MWEB transactions
+"""
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.ltc_util import setup_mweb_chain
+from test_framework.util import assert_equal, assert_raises_rpc_error
+
+class MWEBMempoolTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.setup_clean_chain = True
+        self.num_nodes = 3
+        self.extra_args = [
+            [
+                "-rpcserialversion=0",
+                '-whitelist=noban@127.0.0.1'
+            ],
+            [
+                "-rpcserialversion=1",
+                '-whitelist=noban@127.0.0.1'
+            ],
+            [
+                '-whitelist=noban@127.0.0.1'
+            ],
+        ]
+
+    def run_test(self):
+        node0 = self.nodes[0]
+        node1 = self.nodes[1]
+        node2 = self.nodes[2]
+
+        self.log.info("Setup MWEB chain")
+        setup_mweb_chain(node0)
+        
+        self.log.info("Pegin some coins")
+        node0.sendtoaddress(node0.getnewaddress(address_type='mweb'), 10)
+        node0.generate(1)
+        
+        self.log.info("Create an MWEB-to-MWEB transaction")
+        txid = node0.sendtoaddress(node0.getnewaddress(address_type='mweb'), 2)
+        self.sync_all()
+
+        self.log.info("Assert txid is returned in getrawmempool but tx not returned from getmempoolentry for rpcserialversion=0")
+        assert_equal([txid], node0.getrawmempool())
+        assert_raises_rpc_error(-22, "MWEB-only transaction not serializable for rpcserialversion<2", node0.getmempoolentry, txid)
+
+        self.log.info("Assert txid is returned in getrawmempool but tx not returned from getmempoolentry for rpcserialversion=1")
+        assert_equal([txid], node1.getrawmempool())
+        assert_raises_rpc_error(-22, "MWEB-only transaction not serializable for rpcserialversion<2", node1.getmempoolentry, txid)
+
+        self.log.info("Assert txid is returned in getrawmempool and tx is returned for getmempoolentry for rpcserialversion=2")
+        assert_equal([txid], node2.getrawmempool())
+        assert node2.getmempoolentry(txid) is not None
+
+if __name__ == '__main__':
+    MWEBMempoolTest().main()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -246,6 +246,7 @@ BASE_SCRIPTS = [
     'feature_dersig.py',
     'feature_cltv.py',
     'mweb_basic.py',
+    'mweb_mempool.py',
     'mweb_mining.py',
     'mweb_reorg.py',
     'mweb_pegout_all.py',


### PR DESCRIPTION
<!--
*** Please remove the following help text before submitting: ***

Pull requests without a rationale and clear improvement may be closed
immediately.

GUI-related pull requests should be opened against
https://github.com/bitcoin-core/gui
first. See CONTRIBUTING.md
-->

<!--
Please provide clear motivation for your patch and explain how it improves
Bitcoin Core user experience or Bitcoin Core developer experience
significantly:

* Any test improvements or new tests that improve coverage are always welcome.
* All other changes should have accompanying unit tests (see `src/test/`) or
  functional tests (see `test/`). Contributors should note which tests cover
  modified code. If no tests exist for a region of modified code, new tests
  should accompany the change.
* Bug fixes are most welcome when they come with steps to reproduce or an
  explanation of the potential issue as well as reasoning for the way the bug
  was fixed.
* Features are welcome, but might be rejected due to design or scope issues.
  If a feature is based on a lot of dependencies, contributors should first
  consider building the system outside of Bitcoin Core, if possible.
* Refactoring changes are only accepted if they are required for a feature or
  bug fix or otherwise improve developer experience significantly. For example,
  most "code style" refactoring changes require a thorough explanation why they
  are useful, what downsides they have and why they *significantly* improve
  developer experience or avoid serious programming bugs. Note that code style
  is often a subjective matter. Unless they are explicitly mentioned to be
  preferred in the [developer notes](/doc/developer-notes.md), stylistic code
  changes are usually rejected.
-->

<!--
Bitcoin Core has a thorough review process and even the most trivial change
needs to pass a lot of eyes and requires non-zero or even substantial time
effort to review. There is a huge lack of active reviewers on the project, so
patches often sit for a long time.
-->
